### PR TITLE
Bump MathUtil to 0.2.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "DJBen/MathUtil" ~> 0.1.0
+github "DJBen/MathUtil" ~> 0.2.0
 github "DJBen/SpaceTime" ~> 0.1.0
 github "DJBen/KelvinColor" ~> 0.1.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "MoZhouqi/KMNavigationBarTransition" "1.0.0"
 github "DJBen/KelvinColor" "0.1.0"
-github "DJBen/MathUtil" "0.1.2"
+github "DJBen/MathUtil" "0.2.0"
 github "Weebly/OrderedSet" "v2.0.7"
 github "sharplet/Regex" "1.1.0"
 github "stephencelis/SQLite.swift" "0.11.3"


### PR DESCRIPTION
Bump MathUtil to 0.2.0 for a fix in near zero degree-minute-second conversion.